### PR TITLE
Refactor: 페이지 redirect

### DIFF
--- a/src/pages/authPage/index.tsx
+++ b/src/pages/authPage/index.tsx
@@ -1,9 +1,6 @@
 import AuthForm from "components/Auth/AuthForm";
-import useRedirectByJwt from "hooks/useRedirectByJwt";
 
 function AuthPage() {
-  useRedirectByJwt();
-
   return <AuthForm />;
 }
 

--- a/src/pages/todoPage/index.tsx
+++ b/src/pages/todoPage/index.tsx
@@ -1,6 +1,5 @@
 import styled from "styled-components";
 
-import useRedirectByJwt from "hooks/useRedirectByJwt";
 import TodoInput from "components/Todo/TodoInput";
 import TodoList from "components/Todo/TodoList";
 
@@ -15,7 +14,6 @@ const Wrapper = styled.div`
 
 function TodoPage() {
   const [update, setUpdate] = useState<boolean>(false);
-  useRedirectByJwt();
 
   const handleUpdate = () => {
     setUpdate(!update);

--- a/src/routes/rootRoute.tsx
+++ b/src/routes/rootRoute.tsx
@@ -1,8 +1,23 @@
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import {
+  BrowserRouter,
+  Routes,
+  Route,
+  Navigate,
+  Outlet,
+} from "react-router-dom";
 import AuthPage from "pages/authPage";
 import LandingPage from "pages/landingPage";
 import TodoPage from "pages/todoPage";
 import RootLayout from "pages/layout";
+
+function AuthRoute() {
+  const jwt = localStorage.getItem("jwt");
+  if (jwt) {
+    alert("Todo페이지로 이동합니다.");
+    return <Navigate to="/todo" replace />;
+  }
+  return <Outlet />;
+}
 
 function RootRoute() {
   return (
@@ -10,9 +25,11 @@ function RootRoute() {
       <Routes>
         <Route path="/" element={<RootLayout />}>
           <Route index element={<LandingPage />} />
-          <Route path="signup" element={<AuthPage />} />
-          <Route path="signin" element={<AuthPage />} />
           <Route path="todo" element={<TodoPage />} />
+          <Route element={<AuthRoute />}>
+            <Route path="signup" element={<AuthPage />} />
+            <Route path="signin" element={<AuthPage />} />
+          </Route>
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/routes/rootRoute.tsx
+++ b/src/routes/rootRoute.tsx
@@ -19,13 +19,24 @@ function AuthRoute() {
   return <Outlet />;
 }
 
+function TodoRoute() {
+  const jwt = localStorage.getItem("jwt");
+  if (!jwt) {
+    alert("로그인해주세요.");
+    return <Navigate to="/signin" replace />;
+  }
+  return <Outlet />;
+}
+
 function RootRoute() {
   return (
     <BrowserRouter>
       <Routes>
         <Route path="/" element={<RootLayout />}>
           <Route index element={<LandingPage />} />
-          <Route path="todo" element={<TodoPage />} />
+          <Route element={<TodoRoute />}>
+            <Route path="todo" element={<TodoPage />} />
+          </Route>
           <Route element={<AuthRoute />}>
             <Route path="signup" element={<AuthPage />} />
             <Route path="signin" element={<AuthPage />} />


### PR DESCRIPTION
## 작업 내용

- 라우팅 단계에서 [Navigate](https://reactrouter.com/en/main/components/navigate)와 [Outlet](https://reactrouter.com/en/main/components/outlet)을 사용하여 리다이렉트 하도록 변경

기존 코드는 `useEffect` 안에서 리다이렉트 처리를 하고 있어서 페이지가 렌더링 된 이후에 리다이렉트가 진행되었습니다.
라우팅 단계에서 Navigate와 Outlet을 사용하여 페이지가 렌더링 되기 전에 리다이렉트 되도록 변경했습니다.