### PR TITLE
Refactor: useRedirectByJwt 호출 위치를 최상단 공통 레이아웃으로 변경

### DIFF
--- a/src/hooks/useRedirectByJwt.ts
+++ b/src/hooks/useRedirectByJwt.ts
@@ -22,7 +22,7 @@ const useRedirectByJwt = () => {
       alert("로그인해주세요.");
       navigate("/signin");
     }
-  }, []);
+  }, [navigate, location.pathname]);
 };
 
 export default useRedirectByJwt;

--- a/src/pages/authPage/index.tsx
+++ b/src/pages/authPage/index.tsx
@@ -1,9 +1,6 @@
 import AuthForm from "components/Auth/AuthForm";
-import useRedirectByJwt from "hooks/useRedirectByJwt";
 
 function AuthPage() {
-  useRedirectByJwt();
-
   return <AuthForm />;
 }
 

--- a/src/pages/layout.tsx
+++ b/src/pages/layout.tsx
@@ -4,6 +4,8 @@ import { breakpoints } from "styles/breakPoints";
 import { Outlet } from "react-router-dom";
 import Header from "components/Header/Header";
 
+import useRedirectByJwt from "hooks/useRedirectByJwt";
+
 const Main = styled.main`
   position: relative;
   height: 100vh;
@@ -16,6 +18,8 @@ const Main = styled.main`
 `;
 
 function RootLayout() {
+  useRedirectByJwt();
+
   return (
     <>
       <Header />

--- a/src/pages/todoPage/index.tsx
+++ b/src/pages/todoPage/index.tsx
@@ -1,6 +1,4 @@
 import styled from "styled-components";
-
-import useRedirectByJwt from "hooks/useRedirectByJwt";
 import TodoInput from "components/Todo/TodoInput";
 import TodoList from "components/Todo/TodoList";
 
@@ -15,7 +13,6 @@ const Wrapper = styled.div`
 
 function TodoPage() {
   const [update, setUpdate] = useState<boolean>(false);
-  useRedirectByJwt();
 
   const handleUpdate = () => {
     setUpdate(!update);


### PR DESCRIPTION
리다이렉트 시, alert가 두 번 표시되는 문제 해결.

useRedirectByJwt가 AuthPage, TodoPage에서 각각 실행되어 navigate이 두 번 호출되어 발생한 문제.